### PR TITLE
fix: IDOR + mass-assignment in updateUser / deleteUser

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -45,7 +45,12 @@ export const updateUser = async (req, res) => {
 
 export const deleteUser = async (req, res) => {
   try {
-    const user = await User.findByIdAndDelete(req.params.id);
+    // Scope deletes to the authenticated user only (prevents IDOR)
+    if (req.params.id !== req.user.id) {
+      return res.status(403).json({ errors: ['Forbidden'] });
+    }
+
+    const user = await User.findByIdAndDelete(req.user.id);
     if (!user) return res.status(404).json({ errors: ['User not found'] });
     res.json({ message: 'User deleted successfully' });
   } catch (error) {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -24,7 +24,17 @@ export const viewSingleUser = async (req, res) => {
 
 export const updateUser = async (req, res) => {
   try {
-    const user = await User.findByIdAndUpdate(req.params.id, req.body, { new: true }).select('-password');
+    // Scope updates to the authenticated user only (prevents IDOR)
+    if (req.params.id !== req.user.id) {
+      return res.status(403).json({ errors: ['Forbidden'] });
+    }
+
+    // Whitelist editable fields (prevents mass-assignment of email/password/role).
+    // Password changes go through the dedicated reset flow in authController.
+    const updates = {};
+    if (req.body.name !== undefined) updates.name = req.body.name;
+
+    const user = await User.findByIdAndUpdate(req.user.id, updates, { new: true }).select('-password');
     if (!user) return res.status(404).json({ errors: ['User not found'] });
     res.json(user);
   } catch (error) {


### PR DESCRIPTION
## Problem

`updateUser` and `deleteUser` (server/controllers/userController.js) both took the target id from `req.params.id`, and `updateUser` also wrote raw `req.body` straight into `findByIdAndUpdate`. Three issues:

- **IDOR (updateUser):** the route is auth-gated but the target id came from the URL param, so any authenticated user could edit any other user by changing `:id`.
- **IDOR (deleteUser):** same class of bug — an authenticated user could delete *any* account by changing `:id`. There is no admin/role concept in the model, so deletion is purely self-service and must be scoped to the caller.
- **Mass-assignment (updateUser):** the whole `req.body` was written, so a caller could overwrite `email` (unique identity) or `password` — the latter bypassing hashing and the dedicated reset flow in `authController`.

## Fix

Scoped to this controller only:

1. **Scope to the authenticated user** — in both handlers, reject with `403` when `req.params.id !== req.user.id`, and act against `req.user.id` (the auth middleware sets `req.user` to the User doc, so `req.user.id` is the trusted id).
2. **Whitelist editable fields (updateUser)** — only `name` is copied from `req.body`. `email` and `password` are never accepted here; password changes go through the existing reset flow in `authController`.

## Notes / caveats

- Response shape (`errors: [...]`) matches the existing controller convention.
- No route changes: `PUT /update/:id` and `DELETE /delete/:id` stay; the param is now validated against the token identity rather than trusted.
- Only `name` is currently whitelisted because that is the only editable non-identity field in the User model. Add fields to the whitelist as the model grows.